### PR TITLE
Create and register FCM notification channel

### DIFF
--- a/src/Channels/FcmChannel.php
+++ b/src/Channels/FcmChannel.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Juzaweb\Modules\Notification\Channels;
+
+use NotificationChannels\Fcm\FcmChannel as BaseFcmChannel;
+use Juzaweb\Modules\Notification\Contracts\NotificationChannelInterface;
+
+class FcmChannel extends BaseFcmChannel implements NotificationChannelInterface
+{
+    public function getLabel(): string
+    {
+        return 'FCM';
+    }
+
+    public function getDescription(): ?string
+    {
+        return 'Send notifications via Firebase Cloud Messaging';
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'label' => $this->getLabel(),
+            'description' => $this->getDescription(),
+        ];
+    }
+}

--- a/src/Providers/NotificationServiceProvider.php
+++ b/src/Providers/NotificationServiceProvider.php
@@ -64,6 +64,10 @@ class NotificationServiceProvider extends ServiceProvider
         $notification->registerChannel('email', function () {
             return app(\Juzaweb\Modules\Notification\Channels\EmailChannel::class);
         });
+
+        $notification->registerChannel('fcm', function () {
+            return app(\Juzaweb\Modules\Notification\Channels\FcmChannel::class);
+        });
     }
 
     protected function registerConfig(): void

--- a/tests/Feature/FcmChannelTest.php
+++ b/tests/Feature/FcmChannelTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Juzaweb\Modules\Notification\Tests\Feature;
+
+use Juzaweb\Modules\Notification\Tests\TestCase;
+use Juzaweb\Modules\Notification\Facades\Notification;
+
+class FcmChannelTest extends TestCase
+{
+    public function test_fcm_channel_is_registered()
+    {
+        $this->assertTrue(Notification::hasChannel('fcm'));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -91,6 +91,7 @@ abstract class TestCase extends Orchestra
     {
         return [
             CoreServiceProvider::class,
+            \Kreait\Laravel\Firebase\ServiceProvider::class,
             \Juzaweb\Modules\Notification\Providers\NotificationServiceProvider::class,
             \Juzaweb\QueryCache\QueryCacheServiceProvider::class,
             \Spatie\Activitylog\ActivitylogServiceProvider::class,
@@ -176,6 +177,20 @@ abstract class TestCase extends Orchestra
         $app['config']->set('app.locale', 'en');
         $app['config']->set('translatable.fallback_locale', 'en');
         $app['config']->set('auth.providers.users.model', \Juzaweb\Modules\Core\Models\User::class);
+        $app['config']->set('firebase.projects.app', [
+            'credentials' => [
+                'type' => 'service_account',
+                'project_id' => 'juzaweb-test',
+                'private_key_id' => '1234567890',
+                'private_key' => '-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQD\n-----END PRIVATE KEY-----\n',
+                'client_email' => 'firebase-adminsdk-12345@juzaweb-test.iam.gserviceaccount.com',
+                'client_id' => '1234567890',
+                'auth_uri' => 'https://accounts.google.com/o/oauth2/auth',
+                'token_uri' => 'https://oauth2.googleapis.com/token',
+                'auth_provider_x509_cert_url' => 'https://www.googleapis.com/oauth2/v1/certs',
+                'client_x509_cert_url' => 'https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-12345%40juzaweb-test.iam.gserviceaccount.com',
+            ],
+        ]);
     }
 
     /**


### PR DESCRIPTION
Create and register `FcmChannel` for Firebase Cloud Messaging support.

This change introduces `Juzaweb\Modules\Notification\Channels\FcmChannel` which implements `NotificationChannelInterface` and extends the base FCM channel.
It also updates the `NotificationServiceProvider` to register this new channel.
Tests have been updated to include necessary Firebase service provider and configuration mocks to support the new channel.

---
*PR created automatically by Jules for task [555345784346709839](https://jules.google.com/task/555345784346709839) started by @juzaweb*